### PR TITLE
[Fixed Typo]: Typo fixed in landing page CTA card

### DIFF
--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -55,7 +55,7 @@ export default function Landing() {
                 >
                     <h4 className="cta-title" style={{ width: '40ch', color: 'var(--h-white)' }}>
                         Want to get into hackathons, open source, designing, software developer and much more... 
-                        You will find someone to collaboarte, for sure.
+                        You will find someone to collaborate with, for sure.
                     </h4>
                     <div className="cta-buttons-wrapper" 
                         style={{ 


### PR DESCRIPTION
[Fixed Typo]: Typo fixed in landing page CTA card

from this
![image](https://user-images.githubusercontent.com/62352288/148170050-77760341-d4e3-4ae0-8e26-bbd000144cd0.png)

to this
![image](https://user-images.githubusercontent.com/62352288/148170064-a7ee84fc-1f49-4c2e-8f82-075f4070c1bf.png)
